### PR TITLE
Fix boolean serialization.

### DIFF
--- a/redis/_pack.pyx
+++ b/redis/_pack.pyx
@@ -57,6 +57,8 @@ cdef bytes _encode(self, value):
         return value
     elif isinstance(value, float):
         return simple_bytes(repr(value))
+    elif isinstance(value, bool):
+        return str(value)
     elif isinstance(value, (int, long)):
         return int_to_decimal_bytes(value)
     elif not isinstance(value, basestring):


### PR DESCRIPTION
I have been able to obtain performance improvements of pack_command with this branch of Redis. 

However, I encountered a bug with booleans. They were being serialized incorrectly into 1 and 0 instead of True and False. This fixes this bug.

Note that bool is a subclass of int, which I believe is the source of the bug.
